### PR TITLE
feat(external): store rabbitmq connection info within keyvault

### DIFF
--- a/tf/common.tf
+++ b/tf/common.tf
@@ -118,6 +118,34 @@ resource "azurerm_key_vault_secret" "sshPubKey" {
   key_vault_id = azurerm_key_vault.main.id
 }
 
+resource "azurerm_key_vault_secret" "rabbitmq-vhost" {
+  count        = var.rabbitMqVhost == null ? 0 : 1
+  name         = "Services--RabbitMq--VirtualHost"
+  value        = var.rabbitMqVhost
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "rabbitmq-user-extension" {
+  count        = var.rabbitMqUserExtension == null ? 0 : 1
+  name         = "rabbitmq-vscode-user"
+  value        = var.rabbitMqUserExtension
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "rabbitmq-password-extension" {
+  count        = var.rabbitMqPasswordExtension == null ? 0 : 1
+  name         = "rabbitmq-vscode-password"
+  value        = var.rabbitMqPasswordExtension
+  key_vault_id = azurerm_key_vault.main.id
+}
+
+resource "azurerm_key_vault_secret" "rabbitmq-user" {
+  count        = var.rabbitMqUser == null ? 0 : 1
+  name         = "Services--RabbitMq--Username"
+  value        = var.rabbitMqUser
+  key_vault_id = azurerm_key_vault.main.id
+}
+
 resource "azurerm_key_vault_secret" "rabbitmq-password" {
   count        = var.rabbitMqPassword == null ? 0 : 1
   name         = "Services--RabbitMq--Password"

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -112,6 +112,26 @@ variable "debugScripts" {
   default     = "false"
 }
 
+variable "rabbitMqVhost" {
+  description = "The virtual host for connecting to RabbitMQ"
+  default     = null
+}
+
+variable "rabbitMqUserExtension" {
+  description = "The username for connecting to RabbitMQ from the VS Code Extension"
+  default     = null
+}
+
+variable "rabbitMqPasswordExtension" {
+  description = "The password for connecting to RabbitMQ from the VS Code Extension"
+  default     = null
+}
+
+variable "rabbitMqUser" {
+  description = "The username for connecting to RabbitMQ"
+  default     = null
+}
+
 variable "rabbitMqPassword" {
   description = "The password for connecting to RabbitMQ"
   default     = null


### PR DESCRIPTION
`rabbitmq-vscode-user` and `rabbitmq-vscode-password` are retrieved by the VS Code Extension (https://dev.azure.com/cc-ppi/General/_git/azdevops-vscode-extension/pullrequest/128).

The other added secrets automatically override the default configuration within the docker-automation (https://dev.azure.com/cc-ppi/General/_git/docker-automation?path=%2Fagent%2Fappsettings.json&version=GBfix-additional-label-bug&line=19&lineEnd=21&lineStartColumn=1&lineEndColumn=37&lineStyle=plain&_a=contents)